### PR TITLE
Add image widget, display shortcut in widget dropdown to edit widget properties modal 

### DIFF
--- a/apps/backend/src/routes/integrations.route.ts
+++ b/apps/backend/src/routes/integrations.route.ts
@@ -1,5 +1,8 @@
 import { Hono } from "hono";
-import { randomUUID } from "crypto";
+import { createHash, randomUUID } from "crypto";
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+import { RedisClient } from "bun";
 
 import {
   createIntegration,
@@ -51,6 +54,14 @@ type CacheRecord = {
   invalidatesAt: number | null;
   createdAt: number;
 };
+
+const previewJsonCache = new Map<string, { body: unknown; expiresAt: number }>();
+const previewRedis = new RedisClient(
+  Bun.env.REDIS_URL || Bun.env.VALKEY_URL || "redis://127.0.0.1:6379",
+);
+const previewJsonMaxBytes = 1_048_576;
+const previewJsonTimeoutMs = 10_000;
+let previewRedisUnavailable = false;
 
 const integrationsRoute = new Hono();
 
@@ -166,6 +177,97 @@ integrationsRoute
         statusText: response.statusText,
         body: await response.text(),
       };
+    }),
+  )
+  .post(
+    "/api/v1/integrations/preview-json",
+    withJson(async (c) => {
+      const { userId } = await requireAuth({ token: readAuthToken(c) });
+      const body = await readJsonBody<any>(c);
+      const target = String(body?.url ?? "").trim();
+      let targetUrl: URL;
+      try {
+        targetUrl = new URL(target);
+      } catch {
+        throw new ApiActionError("Invalid preview URL", 400, {
+          error: "Preview URL must be an absolute HTTP or HTTPS URL",
+        });
+      }
+
+      if (!['http:', 'https:'].includes(targetUrl.protocol)) {
+        throw new ApiActionError("Unsupported preview URL", 400, {
+          error: "Preview URL must use HTTP or HTTPS",
+        });
+      }
+
+      if (!(Bun.env.ALLOW_PRIVATE_PREVIEW_URLS === "true" || Bun.env.ALLOW_PRIVATE_PREVIEW_URLS === "1")) {
+        if (await isPrivatePreviewTarget(targetUrl)) {
+          throw new ApiActionError("Private preview URLs are disabled", 403, {
+            error: "Private preview URLs require ALLOW_PRIVATE_PREVIEW_URLS=true",
+          });
+        }
+      }
+
+      const cacheSeconds = parsePreviewCacheSeconds(
+        body?.invalidateAfter ?? body?.invalidate_after,
+      );
+      const cacheKey = createPreviewCacheKey(userId, target, cacheSeconds);
+      const cached = await getPreviewJsonCache(cacheKey);
+      if (cached !== null) {
+        return { body: cached.body };
+      }
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), previewJsonTimeoutMs);
+      try {
+        const response = await fetch(targetUrl, {
+          headers: { Accept: "application/json" },
+          signal: controller.signal,
+          ...(config.ALLOW_SSL
+            ? ({ tls: { rejectUnauthorized: false } } as any)
+            : {}),
+        } as any);
+        if (!response.ok) {
+          throw new ApiActionError(`Preview request returned HTTP ${response.status}`, 502, {
+            error: `Preview request returned HTTP ${response.status}`,
+          });
+        }
+
+        const contentType = response.headers.get("content-type") ?? "";
+        if (!contentType.includes("json")) {
+          throw new ApiActionError("Preview response is not JSON", 422, {
+            error: "Image endpoint preview must return JSON",
+          });
+        }
+
+        const contentLength = Number(response.headers.get("content-length"));
+        if (Number.isFinite(contentLength) && contentLength > previewJsonMaxBytes) {
+          throw new ApiActionError("Preview response is too large", 413, {
+            error: "Image endpoint JSON response exceeds 1 MiB",
+          });
+        }
+
+        const text = await response.text();
+        if (Buffer.byteLength(text, "utf8") > previewJsonMaxBytes) {
+          throw new ApiActionError("Preview response is too large", 413, {
+            error: "Image endpoint JSON response exceeds 1 MiB",
+          });
+        }
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          throw new ApiActionError("Preview response is invalid JSON", 422, {
+            error: "Image endpoint returned invalid JSON",
+          });
+        }
+
+        await setPreviewJsonCache(cacheKey, parsed, cacheSeconds);
+        return { body: parsed };
+      } finally {
+        clearTimeout(timeout);
+      }
     }),
   )
   .get(
@@ -1275,6 +1377,119 @@ function resolveIntegrationCacheConfig(
 
 function isPlainObject(value: unknown): value is Record<string, any> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parsePreviewCacheSeconds(value: unknown) {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.min(value, 30 * 24 * 60 * 60);
+  }
+  if (typeof value !== "string") return 300;
+
+  const match = value.trim().toLowerCase().match(
+    /^(\d+(?:\.\d+)?)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|w|week|weeks)$/,
+  );
+  if (!match) return 300;
+  const amount = Number(match[1]);
+  const unit = match[2];
+  const multiplier = /^s/.test(unit) || unit === "second" || unit === "seconds"
+    ? 1
+    : /^(m|min)/.test(unit) || unit === "minute" || unit === "minutes"
+    ? 60
+    : /^(h|hr)/.test(unit) || unit === "hour" || unit === "hours"
+    ? 60 * 60
+    : /^(d|day)/.test(unit)
+    ? 24 * 60 * 60
+    : 7 * 24 * 60 * 60;
+  return Number.isFinite(amount) && amount > 0
+    ? Math.min(amount * multiplier, 30 * 24 * 60 * 60)
+    : 300;
+}
+
+function createPreviewCacheKey(userId: string, url: string, cacheSeconds: number) {
+  const digest = createHash("sha256")
+    .update(`${url}:${cacheSeconds}`)
+    .digest("hex");
+  return `dashwise:image-preview:${userId}:${digest}`;
+}
+
+async function getPreviewJsonCache(key: string) {
+  if (!previewRedisUnavailable) {
+    try {
+      const raw = await previewRedis.send("GET", [key]);
+      if (typeof raw === "string" && raw) {
+        const body = JSON.parse(raw);
+        return { body };
+      }
+      return null;
+    } catch {
+      previewRedisUnavailable = true;
+    }
+  }
+
+  const cached = previewJsonCache.get(key);
+  if (!cached || cached.expiresAt <= Date.now()) {
+    if (cached) previewJsonCache.delete(key);
+    return null;
+  }
+  return { body: cached.body };
+}
+
+async function setPreviewJsonCache(key: string, body: unknown, cacheSeconds: number) {
+  const expiresAt = Date.now() + cacheSeconds * 1000;
+  if (!previewRedisUnavailable) {
+    try {
+      await previewRedis.send("SET", [
+        key,
+        JSON.stringify(body),
+        "EX",
+        String(Math.max(1, Math.ceil(cacheSeconds))),
+      ]);
+      return;
+    } catch {
+      previewRedisUnavailable = true;
+    }
+  }
+
+  if (previewJsonCache.size >= 1000) {
+    for (const [cachedKey, record] of previewJsonCache) {
+      if (record.expiresAt <= Date.now()) previewJsonCache.delete(cachedKey);
+    }
+    if (previewJsonCache.size >= 1000) {
+      const oldestKey = previewJsonCache.keys().next().value;
+      if (oldestKey) previewJsonCache.delete(oldestKey);
+    }
+  }
+  previewJsonCache.set(key, { body, expiresAt });
+}
+
+async function isPrivatePreviewTarget(url: URL) {
+  const host = url.hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local")) return true;
+  if (isPrivateIp(host)) return true;
+  if (isIP(host)) return false;
+
+  try {
+    const addresses = await lookup(host, { all: true, verbatim: true });
+    return addresses.some(({ address }) => isPrivateIp(address));
+  } catch {
+    throw new ApiActionError("Unable to validate preview URL", 400, {
+      error: "Preview URL hostname could not be resolved",
+    });
+  }
+}
+
+function isPrivateIp(value: string) {
+  const normalized = value.toLowerCase().replace(/^\[|\]$/g, "");
+  if (normalized === "::1" || normalized === "::") return true;
+  if (normalized.startsWith("fc") || normalized.startsWith("fd") || normalized.startsWith("fe8") || normalized.startsWith("fe9") || normalized.startsWith("fea") || normalized.startsWith("feb")) return true;
+  if (normalized.startsWith("::ffff:")) return isPrivateIp(normalized.slice(7));
+  if (isIP(normalized) !== 4) return false;
+
+  const octets = normalized.split(".").map(Number);
+  const [first, second] = octets;
+  return first === 0 || first === 10 || first === 127 || first === 169 && second === 254 ||
+    first === 172 && second >= 16 && second <= 31 || first === 192 && second === 168 ||
+    first === 100 && second >= 64 && second <= 127 || first === 198 && second === 18;
 }
 
 function normalizeTimezone(raw: unknown): string | undefined {

--- a/apps/web/src/app/(authenticated)/settings/pages/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/pages/page.tsx
@@ -1,5 +1,6 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { usePageConfig } from "@/hooks/usePageConfig";
 import { updatePageConfigAction } from '@/lib/apiClient';
 import { getConsumerDataAction } from '@/lib/apiClient';
@@ -71,6 +72,7 @@ export default function SettingsPagesPage() {
   }, [homeConfig?.pages]);
 
   const [selectedPage, setSelectedPage] = useState("home");
+  const [searchParams, setSearchParams] = useSearchParams();
   const { pageConfig: selectedConfig } = usePageConfig({
     pageName: selectedPage,
   });
@@ -97,6 +99,13 @@ export default function SettingsPagesPage() {
   const [clockStyle, setClockStyle] = useState<Record<string, any>>(DEFAULT_CLOCK_STYLE);
   const [fonts, setFonts] = useState<Array<{ name: string; path: string }>>([]);
   const [glanceablesCatalog, setGlanceablesCatalog] = useState<GlanceableCatalogItem[]>([]);
+
+  useEffect(() => {
+    const requestedPage = searchParams.get("editPage");
+    if (requestedPage && pages.includes(requestedPage) && requestedPage !== selectedPage) {
+      setSelectedPage(requestedPage);
+    }
+  }, [pages, searchParams, selectedPage]);
 
   const hasLoadedConfigRef = useRef(false);
   const lastSavedSignatureRef = useRef("");
@@ -320,6 +329,27 @@ export default function SettingsPagesPage() {
     [withAuth],
   );
 
+  const editWidgetRequest = useMemo(() => {
+    const requestedPage = searchParams.get("editPage") ?? "home";
+    const rawTarget = searchParams.get("editWidget") ?? "";
+    const parts = rawTarget.split(":");
+    if (requestedPage !== selectedPage || parts.length < 2) return null;
+    const column = parts[0];
+    const hasIndex = parts.length >= 3 && /^\d+$/.test(parts[parts.length - 1]);
+    const widgetIndex = hasIndex ? Number(parts[parts.length - 1]) : undefined;
+    const widgetId = parts.slice(1, hasIndex ? -1 : undefined).join(":");
+    if (!(["left", "middle", "right"] as ColumnName[]).includes(column as ColumnName) || !widgetId) return null;
+    return { column: column as ColumnName, widgetId, widgetIndex };
+  }, [searchParams, selectedPage]);
+
+  const handleEditWidgetRequestHandled = useCallback(() => {
+    setSearchParams((current) => {
+      const next = new URLSearchParams(current);
+      next.delete("editWidget");
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
+
   useEffect(() => {
     if (!hasLoadedConfigRef.current) {
       return;
@@ -386,6 +416,8 @@ export default function SettingsPagesPage() {
         clockStyle={clockStyle}
         setClockStyle={setClockStyle}
         fonts={fonts}
+        editWidgetRequest={editWidgetRequest}
+        onEditWidgetRequestHandled={handleEditWidgetRequestHandled}
       />
     </div>
   );

--- a/apps/web/src/components/dashboard/DashboardLayoutTemplate.tsx
+++ b/apps/web/src/components/dashboard/DashboardLayoutTemplate.tsx
@@ -2,9 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
-import { Link, useSearchParams } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { Icon } from "@iconify-icon/react";
-import { EyeOff, Maximize2, MoreHorizontal, RefreshCw } from "lucide-react";
+import { Edit3, EyeOff, Maximize2, MoreHorizontal, RefreshCw } from "lucide-react";
 import PagesTabs from "../PagesTabs";
 import UpdateDetailsDialogComponent from "./UpdateDetailsDialog";
 import QuickLaunchPopover from "./QuickLaunchPopover";
@@ -30,7 +30,15 @@ type WidgetMenuState = {
     refreshVersion: number;
     size: WidgetSize;
     blurred: boolean;
+    menuOpen: boolean;
 };
+
+function hasWidgetProperties(config: Record<string, any>) {
+    const ignored = new Set(["className", "height", "index", "configKey", "input", "properties"]);
+    return Object.keys(config).some((key) => !ignored.has(key)) ||
+        Object.keys(config.input ?? {}).length > 0 ||
+        Object.keys(config.properties ?? {}).some((key) => !ignored.has(key));
+}
 
 const WIDGET_SIZE_CLASSNAME: Record<WidgetSize, string> = {
     auto: "",
@@ -89,6 +97,7 @@ export default function DashboardLayoutTemplate({
     isLoading?: boolean;
 }) {
     const [searchParams] = useSearchParams();
+    const navigate = useNavigate();
     const { token, withAuth } = useAuth();
     const openFromURL = searchParams.get("search") === "1";
     const hasSearchBarWidget = useMemo(() => {
@@ -385,6 +394,7 @@ export default function DashboardLayoutTemplate({
             refreshVersion: 0,
             size: "auto",
             blurred: false,
+            menuOpen: false,
         };
 
     const updateWidgetMenuState = (
@@ -396,6 +406,7 @@ export default function DashboardLayoutTemplate({
                 refreshVersion: 0,
                 size: "auto" as WidgetSize,
                 blurred: false,
+                menuOpen: false,
             };
             return { ...current, [baseKey]: updater(previous) };
         });
@@ -428,6 +439,10 @@ export default function DashboardLayoutTemplate({
         }));
     };
 
+    const editWidgetProperties = (columnName: Column, entryKey: string, entryIndex: number) => {
+        navigate(`/settings/pages?editPage=${encodeURIComponent(pageName ?? "home")}&editWidget=${encodeURIComponent(`${columnName}:${entryKey}:${entryIndex}`)}`);
+    };
+
     const renderWidgetMenuWrapper = ({
         baseKey,
         wrapperClass,
@@ -435,6 +450,8 @@ export default function DashboardLayoutTemplate({
         ref,
         style,
         showMenu = true,
+        onEditProperties,
+        darkenOnMenu = false,
     }: {
         baseKey: string;
         wrapperClass: string;
@@ -442,6 +459,8 @@ export default function DashboardLayoutTemplate({
         ref?: (node: HTMLElement | null) => void;
         style?: CSSProperties;
         showMenu?: boolean;
+        onEditProperties?: () => void;
+        darkenOnMenu?: boolean;
     }) => {
         const state = getWidgetMenuState(baseKey);
         const sizeClass = WIDGET_SIZE_CLASSNAME[state.size];
@@ -455,9 +474,15 @@ export default function DashboardLayoutTemplate({
                 <div key={state.refreshVersion} className={state.size === "auto" ? undefined : "h-full"}>
                     {children}
                 </div>
+                {darkenOnMenu && state.menuOpen && (
+                    <div className="pointer-events-none absolute inset-0 z-10 rounded-xl bg-black/50" />
+                )}
                 {showMenu && (
                     <div className="absolute right-2 top-2 z-30 opacity-0 transition-opacity group-hover/widget-menu:opacity-100 focus-within:opacity-100">
-                        <DropdownMenu>
+                        <DropdownMenu
+                            open={state.menuOpen}
+                            onOpenChange={(open) => updateWidgetMenuState(baseKey, (current) => ({ ...current, menuOpen: open }))}
+                        >
                             <DropdownMenuTrigger asChild>
                                 <button
                                     type="button"
@@ -472,6 +497,12 @@ export default function DashboardLayoutTemplate({
                                     <RefreshCw className="h-4 w-4" />
                                     Refresh data
                                 </DropdownMenuItem>
+                                {onEditProperties && (
+                                    <DropdownMenuItem onClick={onEditProperties}>
+                                        <Edit3 className="h-4 w-4" />
+                                        Edit properties
+                                    </DropdownMenuItem>
+                                )}
                                 <DropdownMenuItem onClick={() => resizeWidget(baseKey)}>
                                     <Maximize2 className="h-4 w-4" />
                                     Resize widget
@@ -501,6 +532,7 @@ export default function DashboardLayoutTemplate({
         columnName: Column,
         entryKey: string,
         entryConfig: Record<string, any> | null | undefined,
+        entryIndex: number,
     ) => {
         const cfg = entryConfig ?? {};
         const wrapperClass = ["mb-3", cfg.className].filter(Boolean).join(
@@ -577,6 +609,10 @@ export default function DashboardLayoutTemplate({
                     baseKey,
                     wrapperClass,
                     showMenu: entryKey !== "glanceable-clock",
+                    onEditProperties: (entryKey === "image" || hasWidgetProperties(cfg))
+                        ? () => editWidgetProperties(columnName, entryKey, entryIndex)
+                        : undefined,
+                    darkenOnMenu: entryKey === "image",
                     children: renderWidget({
                         type: entryKey,
                         consumerKey: typeof cfg.configKey === "string" && cfg.configKey.trim()

--- a/apps/web/src/components/settings/pages/DashboardWidgetPreview.tsx
+++ b/apps/web/src/components/settings/pages/DashboardWidgetPreview.tsx
@@ -93,6 +93,8 @@ type DashboardWidgetPreviewProps = {
   clockStyle: Record<string, any>;
   setClockStyle: Dispatch<SetStateAction<Record<string, any>>>;
   fonts: Array<{ name: string; path: string }>;
+  editWidgetRequest?: { column: ColumnName; widgetId: string; widgetIndex?: number } | null;
+  onEditWidgetRequestHandled?: () => void;
 };
 
 function WidgetTile({
@@ -107,6 +109,8 @@ function WidgetTile({
   onEditClockPart,
   clockSelection,
   glanceableNames,
+  openForEdit,
+  onEditWidgetRequestHandled,
 }: {
   columnWidget: ColumnWidget;
   widgetConfig?: WidgetCatalogItem;
@@ -119,6 +123,8 @@ function WidgetTile({
   onEditClockPart?: (part: GlanceableSide | "clock") => void;
   clockSelection?: ClockGlanceableSelection;
   glanceableNames?: Record<string, string>;
+  openForEdit?: boolean;
+  onEditWidgetRequestHandled?: () => void;
 }) {
   const { withAuth } = useAuth();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -307,6 +313,12 @@ function WidgetTile({
     ...(columnWidget.input ?? {}),
   };
   const isClockWidget = columnWidget.type === "main-clock" || columnWidget.type === "glanceable-clock";
+
+  useEffect(() => {
+    if (!openForEdit || !canEditData) return;
+    setIsDataDialogOpen(true);
+  }, [canEditData, openForEdit]);
+
   const handleSaveHeight = () => {
     const nextHeight = parseWidgetHeight(heightDraft);
     onUpdateProperties(columnWidget.id, nextHeight !== undefined
@@ -371,7 +383,13 @@ function WidgetTile({
             )}
             <div className="flex items-center justify-center gap-1">
               {canEditData && (
-                <Dialog open={isDataDialogOpen} onOpenChange={setIsDataDialogOpen}>
+                <Dialog
+                  open={isDataDialogOpen}
+                  onOpenChange={(open) => {
+                    setIsDataDialogOpen(open);
+                    if (!open) onEditWidgetRequestHandled?.();
+                  }}
+                >
                   <DialogTrigger asChild>
                     <button
                       type="button"
@@ -381,7 +399,7 @@ function WidgetTile({
                       <Edit3 className="h-4 w-4" />
                     </button>
                   </DialogTrigger>
-                <DialogContent className="frosted">
+                <DialogContent className="frosted max-h-[90vh] overflow-y-auto">
                   <DialogHeader>
                     <DialogTitle>{supportsUserCustomizations ? "Edit Widget Settings" : "Edit Widget Input"}</DialogTitle>
                     <DialogDescription>
@@ -1100,6 +1118,8 @@ export function DashboardWidgetPreview({
   clockStyle,
   setClockStyle,
   fonts,
+  editWidgetRequest,
+  onEditWidgetRequestHandled,
 }: DashboardWidgetPreviewProps) {
   const [activeId, setActiveId] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState<{ zone: ColumnName; index: number } | null>(null);
@@ -1326,11 +1346,16 @@ export function DashboardWidgetPreview({
                           items={columns[column].map((item) => item.id)}
                           strategy={verticalListSortingStrategy}
                         >
-                          {columns[column].map((widget) => (
+                          {columns[column].map((widget, widgetIndex) => (
                             <div key={widget.id}>
                               <WidgetTile
                                 columnWidget={widget}
                                 widgetConfig={widgetCatalog.find((item) => item.key === widget.type)}
+                                openForEdit={editWidgetRequest?.column === column &&
+                                  (editWidgetRequest.widgetId === widget.id ||
+                                    (editWidgetRequest.widgetId === widget.type &&
+                                      (editWidgetRequest.widgetIndex === undefined || editWidgetRequest.widgetIndex === widgetIndex)))}
+                                onEditWidgetRequestHandled={onEditWidgetRequestHandled}
                                 isActive={activeId === widget.id}
                                 onRemove={() => removeWidget(column, widget.id)}
                                 onEditClockPart={openClockEditor}

--- a/apps/web/src/components/settings/pages/DashboardWidgetPreview.tsx
+++ b/apps/web/src/components/settings/pages/DashboardWidgetPreview.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState, useCallback, type Dispatch, type ReactNode, type SetStateAction } from "react";
 import useAuth from "@/context/useAuth";
-import { getConsumerDataAction } from '@/lib/apiClient';
+import { getConsumerDataAction, previewImageSourceAction } from '@/lib/apiClient';
 import {
   closestCenter,
   DndContext,
@@ -574,6 +574,19 @@ function WidgetInputEditor({
     return <ShortcutsPicker value={shortcutIds} onChange={(nextIds) => onChange({ ...inputDraft, shortcutIds: nextIds })} />;
   }
 
+  if (widgetType === "image") {
+    return (
+      <ImageWidgetInputEditor
+        schema={schema}
+        inputDraft={inputDraft}
+        onChange={onChange}
+        dataError={dataError}
+        setDataError={setDataError}
+        widgetId={widgetId}
+      />
+    );
+  }
+
   return (
     <WidgetPropertiesForm
       idPrefix={`widget-input-${widgetId}`}
@@ -585,6 +598,185 @@ function WidgetInputEditor({
       emptyMessage="No input properties for this widget."
     />
   );
+}
+
+function ImageWidgetInputEditor({
+  schema,
+  inputDraft,
+  onChange,
+  dataError,
+  setDataError,
+  widgetId,
+}: {
+  schema?: Record<string, any>;
+  inputDraft: Record<string, any>;
+  onChange: (next: Record<string, any>) => void;
+  dataError: string | null;
+  setDataError: (value: string | null) => void;
+  widgetId: string;
+}) {
+  const { withAuth } = useAuth();
+  const imageUrl = inputDraft.url ?? inputDraft.image_url ?? inputDraft.imageUrl;
+  const imageUrlPath = inputDraft.image_url_property ?? inputDraft.image_url_path ?? inputDraft.imageUrlProperty ?? "";
+  const [resolvedUrl, setResolvedUrl] = useState("");
+  const [isResolvingUrl, setIsResolvingUrl] = useState(false);
+  const [urlError, setUrlError] = useState<string | null>(null);
+  const propertySchema = { ...(schema ?? {}) };
+  delete propertySchema.image_url_property;
+  delete propertySchema.image_url_path;
+  delete propertySchema.imageUrlProperty;
+  const formValue = { ...inputDraft };
+  delete formValue.image_url_property;
+  delete formValue.image_url_path;
+  delete formValue.imageUrlProperty;
+
+  useEffect(() => {
+    const sourceUrl = String(imageUrl ?? "").trim();
+    const path = String(imageUrlPath ?? "").trim();
+    let cancelled = false;
+
+    setUrlError(null);
+    if (!sourceUrl) {
+      setResolvedUrl("");
+      setIsResolvingUrl(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    if (isImageUrl(sourceUrl)) {
+      setResolvedUrl(sourceUrl);
+      setIsResolvingUrl(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setResolvedUrl("");
+    setIsResolvingUrl(true);
+    void withAuth((auth) => previewImageSourceAction(
+      auth,
+      sourceUrl,
+      inputDraft.invalidate_after ?? inputDraft.invalidateAfter,
+    ))
+      .then((payload) => payload.body)
+      .then((body) => {
+        if (cancelled) return;
+        const selected = path ? getImagePath(body, path) : findImageUrl(body);
+        const nextUrl = typeof selected === "string" ? selected : findImageUrl(selected);
+        if (!nextUrl) throw new Error("No image URL found in response");
+        setResolvedUrl(nextUrl);
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setUrlError(error instanceof Error ? error.message : String(error));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setIsResolvingUrl(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [imageUrl, imageUrlPath, withAuth]);
+
+  return (
+    <div className="space-y-3">
+      <WidgetPropertiesForm
+        idPrefix={`widget-input-${widgetId}`}
+        schema={propertySchema}
+        value={formValue}
+        onChange={(next) => onChange({ ...next, ...pickImageUrlProperty(inputDraft) })}
+        onError={setDataError}
+        error={dataError}
+        emptyMessage="No image input properties for this widget."
+      />
+      {!isImageUrl(String(imageUrl ?? "")) && (
+        <div className="space-y-1.5 rounded-lg border border-white/10 bg-black/15 p-3">
+          <label htmlFor={`widget-input-${widgetId}-image-url-property`} className="text-sm font-medium text-white">
+            Image URL Path
+          </label>
+          <p className="text-xs text-white/50">
+            JSON path containing image URL, for example <code>img.url</code> or <code>thumbnail</code>.
+          </p>
+          <input
+            id={`widget-input-${widgetId}-image-url-property`}
+            type="text"
+            value={String(inputDraft.image_url_property ?? inputDraft.image_url_path ?? "")}
+            onChange={(event) => onChange({ ...inputDraft, image_url_property: event.target.value })}
+            className="w-full rounded-md border border-white/15 bg-black/20 px-3 py-2 text-sm outline-none"
+            placeholder="img.url"
+          />
+        </div>
+      )}
+      <div className="rounded-lg border border-white/10 bg-black/15 p-3">
+        <p className="text-xs uppercase tracking-wide text-white/50">Resolved URL</p>
+        {isResolvingUrl ? (
+          <p className="mt-1 text-sm text-white/60">Resolving image URL...</p>
+        ) : resolvedUrl ? (
+          <p className="mt-1 break-all text-sm text-white/90">{resolvedUrl}</p>
+        ) : (
+          <p className="mt-1 text-sm text-white/60">{urlError ?? "No image URL resolved."}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function pickImageUrlProperty(input: Record<string, any>) {
+  if (input.image_url_property !== undefined) {
+    return { image_url_property: input.image_url_property };
+  }
+  if (input.image_url_path !== undefined) {
+    return { image_url_path: input.image_url_path };
+  }
+  if (input.imageUrlProperty !== undefined) {
+    return { imageUrlProperty: input.imageUrlProperty };
+  }
+  return {};
+}
+
+function isImageUrl(value: string) {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return false;
+  if (normalized.startsWith("data:image/")) return true;
+  return /(?:\.(?:avif|gif|jpe?g|png|svg|webp)|\/(?:avif|gif|jpe?g|png|svg|webp))(?:[?#].*)?$/.test(normalized);
+}
+
+function getImagePath(value: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((current, segment) => {
+    if (current === null || current === undefined || typeof current !== "object") return undefined;
+    return (current as Record<string, unknown>)[segment];
+  }, value);
+}
+
+function findImageUrl(value: unknown, keyHint = ""): string | undefined {
+  if (typeof value === "string") {
+    const candidate = value.trim();
+    if (isImageUrl(candidate) || imageKeyScore(keyHint) > 0) return candidate;
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findImageUrl(item, keyHint);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (!value || typeof value !== "object") return undefined;
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => imageKeyScore(right) - imageKeyScore(left));
+  for (const [key, child] of entries) {
+    const found = findImageUrl(child, key);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function imageKeyScore(key: string) {
+  return /^(image|img|thumbnail|thumb|src|url|href|path)(_url)?$/i.test(key) ? 2 : 0;
 }
 
 function DisplayedItemRow({

--- a/apps/web/src/components/widgets/Widget.tsx
+++ b/apps/web/src/components/widgets/Widget.tsx
@@ -21,6 +21,7 @@ import VerticalList from "@dashwise/integrationskit/templates/VerticalList";
 import LinkView from "./LinkView";
 import SearchBar from "./SearchBar";
 import IframeTemplate from "@dashwise/integrationskit/templates/IFrame";
+import ImageTemplate from "@dashwise/integrationskit/templates/Image";
 import Widget from "@dashwise/integrationskit/Widget";
 import ProgressWidget from "./ProgressWidget";
 import ShortcutsWidget from "./ShortcutsWidget";
@@ -32,6 +33,7 @@ import {
   getLinksCollectionsAction,
   getLinksItemsAction,
   getNewsFeedAction,
+  previewImageSourceAction,
 } from '@/lib/apiClient';
 
 export type WidgetProps = {
@@ -119,6 +121,9 @@ export function renderWidget({
 
     case "iframe":
       return <IframeWidget className={finalClassName} params={renderParams} />;
+
+    case "image":
+      return <ImageWidget className={finalClassName} params={renderParams} isPreview={isPreview} />;
 
     default:
       return (
@@ -396,6 +401,171 @@ function IframeWidget({
       }}
     />
   );
+}
+
+function ImageWidget({
+  className,
+  params,
+  isPreview,
+}: {
+  className?: string;
+  params?: Record<string, any>;
+  isPreview?: boolean;
+}) {
+  const localization = useLocalization();
+  const { withAuth } = useAuth();
+  const { url, image_url, imageUrl, alt, min_height, max_height, object_fit, click_action, clickAction, action, invalidate_after, invalidateAfter, title, icon, title_url, titleUrl, title_action } = params ?? {};
+  const sourceUrl = String(url || image_url || imageUrl || "").trim();
+  const imageUrlPath = String(params?.image_url_property ?? params?.image_url_path ?? params?.imageUrlProperty ?? "").trim();
+  const titleTemplate = typeof title === "string" ? title : "";
+  const [resolvedUrl, setResolvedUrl] = useState("");
+  const [resolvedTitle, setResolvedTitle] = useState(titleTemplate || imageFileName(sourceUrl));
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+
+    if (!sourceUrl) {
+      setResolvedUrl("");
+      setResolvedTitle(titleTemplate || imageFileName(sourceUrl));
+      setLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    if (isImageUrl(sourceUrl)) {
+      setResolvedUrl(sourceUrl);
+      setResolvedTitle(titleTemplate || imageFileName(sourceUrl));
+      setLoading(false);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setResolvedUrl("");
+    setResolvedTitle(titleTemplate);
+    setLoading(true);
+    void withAuth((auth) => previewImageSourceAction(auth, sourceUrl, invalidate_after ?? invalidateAfter))
+      .then((payload) => {
+        const selected = imageUrlPath
+          ? getImagePath(payload.body, imageUrlPath)
+          : findImageUrl(payload.body);
+        const nextUrl = typeof selected === "string" ? selected : findImageUrl(selected);
+        if (!nextUrl) throw new Error("No image URL found in response");
+        if (!cancelled) {
+          setResolvedUrl(nextUrl);
+          const resolvedTitle = resolveImageTitle(titleTemplate, payload.body);
+          setResolvedTitle(resolvedTitle || imageFileName(nextUrl));
+        }
+      })
+      .catch((reason) => {
+        if (!cancelled) setError(reason instanceof Error ? reason.message : String(reason));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [imageUrlPath, isPreview, sourceUrl, titleTemplate, withAuth]);
+
+  if (loading) return <WidgetLoadingState className={className} />;
+  if (error) return <WidgetErrorState className={className} message={error} />;
+
+  return (
+    <ImageTemplate
+      resolved={{
+        header: {
+          title: resolvedTitle,
+          show: !!resolvedTitle,
+          icon: icon || "",
+          titleAction: title_url || titleUrl || title_action || "",
+        },
+        image: {
+          url: resolvedUrl,
+          action: click_action || clickAction || action || "",
+          alt: alt || resolvedTitle || title || "",
+          minHeight: min_height,
+          maxHeight: max_height,
+          objectFit: object_fit,
+        },
+        raw: params ?? {},
+      }}
+      className={className}
+      formatters={{
+        formatTemperature: localization.formatTemperature,
+        formatTime: localization.formatTime,
+        formatDate: localization.formatDate,
+      }}
+    />
+  );
+}
+
+function resolveImageTitle(template: string, body: unknown) {
+  if (!template.includes("${json")) return template;
+  return template.replace(/\$\{json(?:\.([^}]+))?\}/g, (_, path?: string) => {
+    const value = path ? getImagePath(body, path) : body;
+    if (value === undefined || value === null) return "";
+    return typeof value === "string" ? value : JSON.stringify(value);
+  });
+}
+
+function imageFileName(value: string) {
+  if (!value) return "";
+  const withoutQuery = value.split(/[?#]/, 1)[0];
+  const segment = withoutQuery.split("/").filter(Boolean).pop() ?? "";
+  if (!segment || segment.includes(":")) return "";
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function isImageUrl(value: string) {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return false;
+  if (normalized.startsWith("data:image/")) return true;
+  return /(?:\.(?:avif|gif|jpe?g|png|svg|webp)|\/(?:avif|gif|jpe?g|png|svg|webp))(?:[?#].*)?$/.test(normalized);
+}
+
+function getImagePath(value: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((current, segment) => {
+    if (current === null || current === undefined || typeof current !== "object") return undefined;
+    return (current as Record<string, unknown>)[segment];
+  }, value);
+}
+
+function findImageUrl(value: unknown, keyHint = ""): string | undefined {
+  if (typeof value === "string") {
+    const candidate = value.trim();
+    if (isImageUrl(candidate) || imageKeyScore(keyHint) > 0) return candidate;
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findImageUrl(item, keyHint);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (!value || typeof value !== "object") return undefined;
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => imageKeyScore(right) - imageKeyScore(left));
+  for (const [key, child] of entries) {
+    const found = findImageUrl(child, key);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function imageKeyScore(key: string) {
+  return /^(image|img|thumbnail|thumb|src|url|href|path)(_url)?$/i.test(key) ? 2 : 0;
 }
 
 function IntegrationWidget({

--- a/apps/web/src/lib/apiClient.ts
+++ b/apps/web/src/lib/apiClient.ts
@@ -330,6 +330,27 @@ export async function testIntegrationEndpointAction(auth: ActionAuth, target: st
   return extractData(await postIntegrationsTestEndpoint({ body: { auth, target }, headers: authHeaders(auth) }));
 }
 
+export async function previewImageSourceAction(
+  auth: ActionAuth,
+  url: string,
+  invalidateAfter?: string | number,
+) {
+  const response = await fetch(backendUrl("/api/v1/integrations/preview-json"), {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...(authHeaders(auth) ?? {}),
+    },
+    body: JSON.stringify({ url, invalidateAfter }),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(typeof payload?.error === "string" ? payload.error : "Image preview request failed");
+  }
+  return payload as { body?: unknown };
+}
+
 export async function getWidgetPropertiesAction(auth: ActionAuth, widgetSlug: string) {
   return extractData(await getIntegrationsWidgetProperties({ query: { widgetSlug }, headers: authHeaders(auth) }));
 }

--- a/docs/Integrations.md
+++ b/docs/Integrations.md
@@ -44,6 +44,43 @@ References can use runtime paths such as:
 
 Endpoints define HTTP calls to fetch data from external services. Each endpoint includes configuration for the request and `response_mapping` to transform the response into structured data.
 
+### Image widgets
+
+The `image` template supports a direct image URL or an endpoint response. Use `endpoint` with an optional `image_url_property` path when the endpoint returns JSON:
+
+```yaml
+configuration:
+  endpoints:
+    camera:
+      method: GET
+      url: "${CAMERA_URL}/snapshot"
+      response:
+        type: json
+        invalidate:
+          every: "5 minutes"
+  widgets:
+    - name: Camera
+      key: camera-image
+      template: image
+      properties:
+        header:
+         title: Camera
+         title_url: "${CAMERA_URL}"
+         endpoint: camera
+        image_url_property: "img.url"
+        alt: Camera snapshot
+```
+
+If `image_url_property` is omitted, Dashwise searches response JSON for common image fields such as `image`, `img`, `thumbnail`, `src`, and `url`. A direct URL uses `url` instead. Supported image properties include `alt`, `min_height`, `max_height`, and `object_fit`. `click_action` links image itself; `title_url` links header title independently.
+
+Built-in image JSON previews are fetched through the authenticated backend proxy. Private or local targets are blocked by default; set `ALLOW_PRIVATE_PREVIEW_URLS=true` when intentionally using a homelab-local endpoint.
+
+Endpoint caching accepts a duration in `response.invalidate.after` or an aligned recurring boundary in `response.invalidate.every`:
+
+- `after: "6 hours"`, `after: "2 days"`
+- `every: "2 hours"`, `every: "day"`, `every: "week"`, `every: "month"`
+- Existing numeric `cache_ttl` values remain seconds.
+
 ### Response mapping with `iterate`
 
 The `iterate` property in `response_mapping` specifies which array to iterate over when mapping endpoint responses:
@@ -221,6 +258,8 @@ The backend tracks integration cache behavior using:
 - `cache.staleReturned`
 
 Runtime snapshots are persisted and may be served from cache when the integration configuration allows it.
+
+Built-in image JSON previews use Redis when `REDIS_URL` or `VALKEY_URL` is configured. The default connection is `redis://127.0.0.1:6379`. Redis keys are scoped by user and contain a hash of the URL and TTL; raw URLs are not used as key names. If Redis is unavailable, a bounded process-memory fallback is used.
 
 ## Summary
 

--- a/packages/assets/integrations/default.yaml
+++ b/packages/assets/integrations/default.yaml
@@ -75,6 +75,19 @@ configuration:
           url: "https://www.wikipedia.org"
           min_height: 300
           max_height: 600
+    - name: "Image"
+      key: "image"
+      template: "image"
+      category: "Tools"
+      data:
+        input:
+          url: "https://placehold.co/800x450/png"
+          title: ""
+          title_url: ""
+          click_action: ""
+          invalidate_after: "5 minutes"
+          alt: "Image widget"
+          max_height: 600
     - name: "Progress"
       key: "progress"
       template: "progress"

--- a/packages/assets/integrations/example.yaml
+++ b/packages/assets/integrations/example.yaml
@@ -85,6 +85,14 @@ configuration:
               cpu: "usage.cpu"
               memory: "usage.mem"
 
+    camera:
+      method: GET
+      url: "${URL}/camera"
+      response:
+        type: json
+        invalidate:
+          every: "1 hour"
+
   # Computed Fields
   # Process and aggregate data from endpoints.
   computed:
@@ -199,6 +207,24 @@ configuration:
         url: "${URL}/dashboard"
         min_height: 240
         max_height: 720
+
+    - name: "Remote Image"
+      key: "remote-image"
+      template: "image"
+      properties:
+        header:
+          title: "Camera"
+          icon: "fa6-solid:image"
+        endpoint: camera
+        image_url_property: "img.url"
+        title_url: "${CAMERA_URL}"
+        alt: "Camera image"
+        min_height: 180
+        max_height: 600
+
+  # Image endpoints can cache their JSON response. `after` is a duration from
+  # fetch time; `every` uses the next aligned hour/day/week/month boundary.
+  # Examples: "6 hours", "2 days", "every 2 hours", "every week".
 
 # ---------------------------------------------------------
 # 3. Shortcuts

--- a/packages/integrationskit/Widget.tsx
+++ b/packages/integrationskit/Widget.tsx
@@ -10,6 +10,7 @@ import WidgetColumnTemplate from "./templates/WidgetColumn";
 import VerticalList from "./templates/VerticalList";
 import ItemDetailsCard from "./templates/ItemDetailsCard";
 import IframeTemplate from "./templates/IFrame";
+import ImageTemplate from "./templates/Image";
 import AppIcon from "@dashwise/app-icon";
 import type { ResolvedWidget } from "./types";
 
@@ -203,6 +204,24 @@ export default function Widget({
         case "icon-details-card":
             return (
                 <ItemDetailsCard
+                    resolved={renderedResolved}
+                    className={className}
+                    formatters={formatters}
+                />
+            );
+
+        case "image":
+            return (
+                <ImageTemplate
+                    resolved={renderedResolved}
+                    className={className}
+                    formatters={formatters}
+                />
+            );
+
+        case "iframe":
+            return (
+                <IframeTemplate
                     resolved={renderedResolved}
                     className={className}
                     formatters={formatters}

--- a/packages/integrationskit/data/getEndpointData.tsx
+++ b/packages/integrationskit/data/getEndpointData.tsx
@@ -124,7 +124,6 @@ export async function resolveEndpointCatalog(
 
 		const endpoint = work.splice(idx, 1)[0];
 		const endpointKey = resolveEndpointCacheKey(endpoint);
-		const ttlSeconds = resolveInvalidateAfterSeconds(endpoint);
 
 		let resolvedEndpoint: ResolvedEndpointData | null = null;
 		if (endpointKey && context.cache) {
@@ -143,8 +142,8 @@ export async function resolveEndpointCatalog(
 				},
 			}, allowInsecureEndpoints);
 
-			if (endpointKey && context.cache && ttlSeconds !== null) {
-				const expiresAt = Date.now() + ttlSeconds * 1000;
+			const expiresAt = resolveEndpointInvalidatesAt(endpoint, Date.now());
+			if (endpointKey && context.cache && expiresAt !== null) {
 				context.cache.set(endpointKey, resolvedEndpoint, expiresAt);
 			}
 		}
@@ -442,8 +441,9 @@ function resolveEndpointCacheKey(endpoint: EndpointDefinition): string | null {
 	return null;
 }
 
-function resolveInvalidateAfterSeconds(
+function resolveEndpointInvalidatesAt(
 	endpoint: EndpointDefinition,
+	now: number,
 ): number | null {
 	const responseDirective = isPlainObject(endpoint.response)
 		? endpoint.response
@@ -451,12 +451,104 @@ function resolveInvalidateAfterSeconds(
 	const invalidate = isPlainObject(responseDirective?.invalidate)
 		? responseDirective.invalidate
 		: null;
-	const afterRaw = invalidate?.after ?? endpoint.cache_ttl;
-	const parsed = Number(afterRaw);
-	if (!Number.isFinite(parsed) || parsed <= 0) {
-		return null;
+	const after = parseCacheDuration(
+		invalidate?.after ?? invalidate?.duration ?? endpoint.invalidate_after ?? endpoint.cache_ttl,
+	);
+	if (after !== null) return now + after * 1000;
+
+	const every = parseCacheInterval(
+		invalidate?.every ?? invalidate?.schedule ?? endpoint.invalidate_every,
+	);
+	return every ? getNextCacheBoundary(every, now) : null;
+}
+
+type CacheInterval = {
+	count: number;
+	unit: "second" | "minute" | "hour" | "day" | "week" | "month";
+};
+
+function parseCacheDuration(value: unknown): number | null {
+	if (typeof value === "number") {
+		return Number.isFinite(value) && value > 0 ? value : null;
 	}
-	return parsed;
+
+	if (typeof value !== "string") return null;
+	const match = value.trim().toLowerCase().match(
+		/^(\d+(?:\.\d+)?)\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|w|week|weeks|mo|month|months)$/,
+	);
+	if (!match) return null;
+
+	const amount = Number(match[1]);
+	if (!Number.isFinite(amount) || amount <= 0) return null;
+	const unit = match[2];
+	const multiplier = /^s/.test(unit) || unit === "second" || unit === "seconds"
+		? 1
+		: /^(m|min)/.test(unit) || unit === "minute" || unit === "minutes"
+		? 60
+		: /^(h|hr)/.test(unit) || unit === "hour" || unit === "hours"
+		? 60 * 60
+		: /^(d|day)/.test(unit)
+		? 24 * 60 * 60
+		: /^(w|week)/.test(unit)
+		? 7 * 24 * 60 * 60
+		: 30 * 24 * 60 * 60;
+	return amount * multiplier;
+}
+
+function parseCacheInterval(value: unknown): CacheInterval | null {
+	if (typeof value !== "string") return null;
+	const match = value.trim().toLowerCase().replace(/^every\s+/, "").match(
+		/^(\d+(?:\.\d+)?)?\s*(s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days|w|week|weeks|mo|month|months)$/,
+	);
+	if (!match) return null;
+
+	const count = match[1] ? Number(match[1]) : 1;
+	if (!Number.isFinite(count) || count <= 0) return null;
+	const rawUnit = match[2];
+	const unit: CacheInterval["unit"] = /^(s|sec|secs|second|seconds)$/.test(rawUnit)
+		? "second"
+		: /^(m|min|mins|minute|minutes)$/.test(rawUnit)
+		? "minute"
+		: /^(h|hr|hrs|hour|hours)$/.test(rawUnit)
+		? "hour"
+		: /^(d|day|days)$/.test(rawUnit)
+		? "day"
+		: /^(w|week|weeks)$/.test(rawUnit)
+		? "week"
+		: "month";
+	return { count, unit };
+}
+
+function getNextCacheBoundary(interval: CacheInterval, now: number) {
+	const date = new Date(now);
+	if (interval.unit === "month") {
+		const monthIndex = date.getFullYear() * 12 + date.getMonth();
+		const nextMonth = Math.floor(monthIndex / interval.count + 1) * interval.count;
+		return new Date(Math.floor(nextMonth / 12), nextMonth % 12, 1).getTime();
+	}
+
+	if (interval.unit === "day") {
+		const next = new Date(date.getFullYear(), date.getMonth(), date.getDate() + interval.count);
+		return next.getTime();
+	}
+
+	if (interval.unit === "week") {
+		const mondayOffset = (date.getDay() + 6) % 7;
+		const next = new Date(
+			date.getFullYear(),
+			date.getMonth(),
+			date.getDate() - mondayOffset + interval.count * 7,
+		);
+		return next.getTime();
+	}
+
+	const unitMs = interval.unit === "second"
+		? 1000
+		: interval.unit === "minute"
+		? 60 * 1000
+		: 60 * 60 * 1000;
+	const next = Math.floor(now / (unitMs * interval.count) + 1) * unitMs * interval.count;
+	return next > now ? next : now + unitMs;
 }
 
 function getOrCreateEndpointFetchPromise(

--- a/packages/integrationskit/data/resolveProperties.tsx
+++ b/packages/integrationskit/data/resolveProperties.tsx
@@ -218,8 +218,120 @@ export function resolveWidgetProperties(opts: ResolveOptions): ResolvedWidget {
     return patchIntegrationIcons(result, env);
   }
 
+  if (template === "image") {
+    const image = resolveImageProperties(props, env, data);
+    const titleUrl = resolveValue(props.title_url ?? props.titleUrl ?? props.title_action, env);
+    const result: ResolvedWidget = {
+      header: titleUrl ? { ...(header ?? {}), titleAction: titleUrl } : header,
+      image,
+      raw: props,
+    };
+    return patchIntegrationIcons(result, env);
+  }
+
   const result: ResolvedWidget = { header, raw: props };
   return patchIntegrationIcons(result, env);
+}
+
+function resolveImageProperties(
+  props: Record<string, any>,
+  env: Record<string, string>,
+  data: Record<string, any> | null,
+) {
+  const imageConfig = isPlainObject(props.image) ? props.image : {};
+  const sourceConfig = isPlainObject(props.source) ? props.source : {};
+  const directUrl = resolveValue(
+    props.url ?? props.image_url ?? props.imageUrl ?? imageConfig.url ?? sourceConfig.url,
+    env,
+  );
+  const endpointKey = resolveValue(
+    props.endpoint ?? props.endpoint_id ?? props.endpointId ?? imageConfig.endpoint ?? sourceConfig.endpoint,
+    env,
+  );
+  const property = resolveValue(
+    props.image_url_property ?? props.imageUrlProperty ?? props.url_property ??
+      props.image_url_path ?? props.imageUrlPath ?? props.property ?? imageConfig.property ??
+      sourceConfig.property ?? sourceConfig.image_url_property ?? sourceConfig.image_url_path,
+    env,
+  );
+
+  let url = directUrl;
+  if ((!url || !looksLikeImageUrl(url)) && data?.endpoints) {
+    const endpoints = data.endpoints as Record<string, any>;
+    const endpoint = endpointKey
+      ? endpoints[String(endpointKey)]
+      : Object.keys(endpoints).length === 1
+      ? endpoints[Object.keys(endpoints)[0]]
+      : undefined;
+    const responses = [endpoint?.mappedResponse, endpoint?.rawResponse];
+    const selected = property
+      ? responses.map((response) => getImagePath(response, property)).find((value) => value !== undefined)
+      : responses.map((response) => findImageUrl(response)).find(Boolean);
+    const discovered = typeof selected === "string" ? selected : findImageUrl(selected);
+    if (discovered) url = discovered;
+  }
+
+  return {
+    url: url || undefined,
+    action: resolveValue(props.click_action ?? props.clickAction ?? props.action ?? imageConfig.action, env),
+    alt: resolveValue(props.alt ?? props.image_alt ?? imageConfig.alt, env),
+    minHeight: resolveNumber(props.min_height ?? props.minHeight ?? imageConfig.min_height, env),
+    maxHeight: resolveNumber(props.max_height ?? props.maxHeight ?? imageConfig.max_height, env),
+    objectFit: resolveObjectFit(props.object_fit ?? props.objectFit ?? imageConfig.object_fit, env),
+  };
+}
+
+function getImagePath(value: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((current, segment) => {
+    if (current === null || current === undefined || typeof current !== "object") return undefined;
+    return (current as Record<string, unknown>)[segment];
+  }, value);
+}
+
+function findImageUrl(value: unknown, keyHint = ""): string | undefined {
+  if (typeof value === "string") {
+    const candidate = value.trim();
+    if (isImageCandidate(candidate, keyHint)) return candidate;
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findImageUrl(item, keyHint);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (!value || typeof value !== "object") return undefined;
+
+  const entries = Object.entries(value as Record<string, unknown>);
+  const prioritized = entries.sort(([left], [right]) => imageKeyScore(right) - imageKeyScore(left));
+  for (const [key, child] of prioritized) {
+    const found = findImageUrl(child, key);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function imageKeyScore(key: string) {
+  return /^(image|img|thumbnail|thumb|src|url|href|path)(_url)?$/i.test(key) ? 2 : 0;
+}
+
+function isImageCandidate(value: string, keyHint: string) {
+  if (!/^(https?:)?\/\//i.test(value) && !/^data:image\//i.test(value) && !/^\//.test(value)) {
+    return false;
+  }
+  return imageKeyScore(keyHint) > 0 || /\.(avif|gif|jpe?g|png|svg|webp)(?:[?#].*)?$/i.test(value) || /^data:image\//i.test(value);
+}
+
+function looksLikeImageUrl(value: string) {
+  return /^(https?:)?\/\//i.test(value) || /^data:image\//i.test(value) || /^\//.test(value);
+}
+
+function resolveObjectFit(value: unknown, env: Record<string, string>) {
+  const resolved = resolveValue(value, env);
+  return ["contain", "cover", "fill", "none", "scale-down"].includes(String(resolved))
+    ? String(resolved) as "contain" | "cover" | "fill" | "none" | "scale-down"
+    : undefined;
 }
 
 function patchIntegrationIcons(res: ResolvedWidget, env: Record<string, any>) {

--- a/packages/integrationskit/package.json
+++ b/packages/integrationskit/package.json
@@ -42,6 +42,16 @@
       "import": "./templates/IFrame.tsx",
       "default": "./templates/IFrame.tsx"
     },
+    "./templates/Image": {
+      "types": "./templates/Image.tsx",
+      "import": "./templates/Image.tsx",
+      "default": "./templates/Image.tsx"
+    },
+    "./templates/image": {
+      "types": "./templates/Image.tsx",
+      "import": "./templates/Image.tsx",
+      "default": "./templates/Image.tsx"
+    },
     "./templates/*": "./templates/*.tsx",
     "./templates/WidgetColumn": "./templates/WidgetColumn.tsx",
     "./static-widgets/CalendarWidgets": "./static-widgets/CalendarWidgets.tsx",

--- a/packages/integrationskit/templates/Image.tsx
+++ b/packages/integrationskit/templates/Image.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React from "react";
+import AppIcon from "@dashwise/app-icon";
+import { Icon } from "@iconify-icon/react";
+import type { ResolvedWidget } from "../types";
+import { renderLocalizedText, type TextFormatters } from "../data/renderText";
+
+interface ImageTemplateProps {
+  resolved: ResolvedWidget;
+  className?: string;
+  formatters?: TextFormatters;
+}
+
+export default function ImageTemplate({
+  resolved,
+  className = "",
+  formatters,
+}: ImageTemplateProps) {
+  const { header, image } = resolved;
+  const configuredTitle = renderLocalizedText(header?.title ?? "", formatters);
+  const title = header?.show !== false
+    ? configuredTitle || imageFileName(image?.url ?? "")
+    : "";
+  const titleAction = header?.titleAction ?? "";
+  const iconUrl = header?.icon ?? "";
+  const hasTitle = Boolean(title || iconUrl);
+  const imageContent = (
+    <div
+      className="w-full flex-1 min-h-0 flex items-center justify-center overflow-hidden rounded-lg bg-black/10"
+      style={{
+        minHeight: image?.minHeight ? `${image.minHeight}px` : undefined,
+        maxHeight: image?.maxHeight ? `${image.maxHeight}px` : "none",
+      }}
+    >
+      <img
+        src={image?.url}
+        alt={image?.alt ?? (typeof title === "string" ? title : "")}
+        title={image?.alt ?? (typeof title === "string" ? title : "")}
+        className="block w-full max-w-full h-auto rounded-lg"
+        style={{
+          maxHeight: image?.maxHeight ? `${image.maxHeight}px` : "none",
+          objectFit: image?.objectFit ?? "contain",
+        }}
+      />
+    </div>
+  );
+
+  if (!image?.url) {
+    return (
+      <div className={`frosted rounded-xl p-4 flex items-center justify-center text-sm opacity-50 ${className}`}>
+        No image URL provided
+      </div>
+    );
+  }
+
+  return (
+    <div className={`frosted rounded-xl overflow-hidden flex flex-col gap-1 ${hasTitle ? "p-2" : ""} ${className}`}>
+      {hasTitle && (
+        <a
+          href={titleAction || "#"}
+          className="font-medium flex w-full text-start items-center gap-1 border-b border-white/5"
+        >
+          <AppIcon
+            source={iconUrl}
+            className={`h-4 w-4 ${iconUrl ? "" : "invisible"}`}
+            alt=""
+            size={16}
+          />
+          <p className="font-semibold truncate flex-1">{title}</p>
+          {titleAction && (
+            <Icon
+              icon="fa6-solid:up-right-from-square"
+              className="text-xs hover:text-primary transition-colors"
+            />
+          )}
+        </a>
+      )}
+      {image.action ? (
+        <a href={image.action} className="block w-full min-h-0">
+          {imageContent}
+        </a>
+      ) : imageContent}
+    </div>
+  );
+}
+
+function imageFileName(value: string) {
+  if (!value) return "";
+  const withoutQuery = value.split(/[?#]/, 1)[0];
+  const segment = withoutQuery.split("/").filter(Boolean).pop() ?? "";
+  if (!segment || segment.includes(":")) return "";
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}

--- a/packages/integrationskit/types.ts
+++ b/packages/integrationskit/types.ts
@@ -45,6 +45,15 @@ export type ResolvedWidget = {
     minHeight?: number;
     maxHeight?: number;
   };
+  /** Populated for template: "image" */
+  image?: {
+    url?: string;
+    action?: string;
+    alt?: string;
+    minHeight?: number;
+    maxHeight?: number;
+    objectFit?: "contain" | "cover" | "fill" | "none" | "scale-down";
+  };
   /** The raw properties object, passed through for custom consumers */
   raw: Record<string, any>;
   progress?: number | null;


### PR DESCRIPTION
Title pretty much speaks for itself.
Closes #320 

Codex summary:
Image Widget
- Added direct/API-backed image rendering with JSON path selection and auto-discovery.
- Added title, title_url, click_action, alt text, filename fallback, sizing, object-fit, and rounded layout.
- Added authenticated preview proxy with SSRF protection, response limits, Redis/memory caching, and invalidation settings.
- Added settings preview/editor, defaults, examples, docs, and package exports.
Edit Properties
- Added widget dropdown shortcut linking directly to settings for selected widget.
- Added query-param targeting by page, column, widget ID/type, and index.
- Added automatic dialog opening and URL cleanup after closing.
- Added menu-state darkening for image widgets and scrollable edit dialog.
Validation: typecheck, lint, YAML validation, source tests, and diff checks pass.
